### PR TITLE
[demo] listen to `webRequest`

### DIFF
--- a/manifest/manifest.chromium.json
+++ b/manifest/manifest.chromium.json
@@ -29,7 +29,8 @@
     "service_worker": "js/background.js"
   },
 
-  "permissions": ["storage"],
+  "permissions": ["storage", "webRequest"],
+  "optional_permissions": ["webRequestBlocking"],
 
   "host_permissions": ["<all_urls>"]
 }

--- a/manifest/manifest.firefox.json
+++ b/manifest/manifest.firefox.json
@@ -29,7 +29,7 @@
     "scripts": ["js/background.js"]
   },
 
-  "permissions": ["storage"],
+  "permissions": ["storage", "webRequest", "webRequestBlocking"],
 
   "host_permissions": ["<all_urls>"]
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,4 +1,13 @@
+import browser from "webextension-polyfill";
+
 function polling() {
   setInterval(() => console.log("polling"), 1000 * 30);
 }
 polling();
+
+browser.webRequest.onBeforeRequest.addListener(
+  (requestDetails) => console.log(`Loading: ${requestDetails.url}`),
+  { urls: ["<all_urls>"] }
+);
+
+console.log("background.ts");


### PR DESCRIPTION
Requires extra permission (Manifest.json):
```json
{
	// ... other configuration
	"permissions": ["storage", "webRequest", "webRequestBlocking"],
}
```

```ts
import browser from "webextension-polyfill";

browser.webRequest.onBeforeRequest.addListener(
  (requestDetails) => console.log(`Loading: ${requestDetails.url}`),
  { urls: ["<all_urls>"] }
);
```